### PR TITLE
Need to specify VMNAME for Updates Proxy

### DIFF
--- a/07_get-started.md
+++ b/07_get-started.md
@@ -163,7 +163,7 @@ The two lines in the middle of the configuration file are giving access to any q
 Then I enable the service updates-proxy-setup for vault (still in dom0):
 
 ``` bash
-qvm-service --enable updates-proxy-setup
+qvm-service --enable vault updates-proxy-setup
 ```
 
 The list of enabled services for _vault_ can be displayed with this commmand:


### PR DESCRIPTION
The ``qvm-service --enable updates-proxy-setup`` did not work until I added the VMNAME before updates-proxy-setup